### PR TITLE
Refs #27 - Error on posting links without http on slack

### DIFF
--- a/links/models.py
+++ b/links/models.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.models import User
 from django.db import models
 from core.services.slack import send_notification_to_slack, get_slack_user
-from .utils import get_title_from_url
+from .utils import get_title_from_url, check_for_http_in_url
 
 
 class LinkManager(models.Manager):
@@ -9,6 +9,7 @@ class LinkManager(models.Manager):
     def create_from_slack(self, slack_url, slack_user_id):
         title = get_title_from_url(slack_url)
         author = get_slack_user(slack_user_id)
+        slack_url = check_for_http_in_url(slack_url)
 
         return self.create(title=title, url=slack_url, author=author)
 

--- a/links/models.py
+++ b/links/models.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.models import User
 from django.db import models
 from core.services.slack import send_notification_to_slack, get_slack_user
-from .utils import get_title_from_url, check_for_http_in_url
+from .utils import get_title_from_url, ensure_http_prefix
 
 
 class LinkManager(models.Manager):
@@ -9,7 +9,7 @@ class LinkManager(models.Manager):
     def create_from_slack(self, slack_url, slack_user_id):
         title = get_title_from_url(slack_url)
         author = get_slack_user(slack_user_id)
-        slack_url = check_for_http_in_url(slack_url)
+        slack_url = ensure_http_prefix(slack_url)
 
         return self.create(title=title, url=slack_url, author=author)
 

--- a/links/tests/test_utils.py
+++ b/links/tests/test_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from links.utils import get_title_from_url
+from links.utils import get_title_from_url, check_for_http_in_url
 
 
 @pytest.mark.django_db
@@ -10,3 +10,13 @@ def test_get_title_from_url_with_meta_title(client):
 @pytest.mark.django_db
 def test_get_title_from_url_without_meta_title(client):
     assert get_title_from_url('https://teamtreehouse.com/home') == 'Treehouse | Sign In'
+
+
+@pytest.mark.django_db
+def test_check_for_http_in_url_with_http_in_url(client):
+    assert check_for_http_in_url('https://api.slack.com/') == 'https://api.slack.com/'
+
+
+@pytest.mark.django_db
+def test_check_for_http_in_url_without_http_in_url(client):
+    assert check_for_http_in_url('api.slack.com/') == 'http://api.slack.com/'

--- a/links/tests/test_utils.py
+++ b/links/tests/test_utils.py
@@ -13,10 +13,10 @@ def test_get_title_from_url_without_meta_title(client):
 
 
 @pytest.mark.django_db
-def test_check_for_http_in_url_with_http_in_url(client):
-    assert check_for_http_in_url('https://api.slack.com/') == 'https://api.slack.com/'
+def test_ensure_http_prefix_with_http_in_url(client):
+    assert ensure_http_prefix('https://api.slack.com/') == 'https://api.slack.com/'
 
 
 @pytest.mark.django_db
-def test_check_for_http_in_url_without_http_in_url(client):
-    assert check_for_http_in_url('api.slack.com/') == 'http://api.slack.com/'
+def test_ensure_http_prefix_without_http_in_url(client):
+    assert ensure_http_prefix('api.slack.com/') == 'http://api.slack.com/'

--- a/links/tests/test_utils.py
+++ b/links/tests/test_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from links.utils import get_title_from_url, check_for_http_in_url
+from links.utils import get_title_from_url, ensure_http_prefix
 
 
 @pytest.mark.django_db

--- a/links/utils.py
+++ b/links/utils.py
@@ -1,7 +1,11 @@
 import requests
 from bs4 import BeautifulSoup
 
+
 def get_title_from_url(slack_url):
+    if 'http' not in slack_url:
+        slack_url = 'http://' + slack_url
+
     soup_url = BeautifulSoup(requests.get(slack_url).text)
     try:
         title = soup_url.find('meta', property='og:title').get('content')

--- a/links/utils.py
+++ b/links/utils.py
@@ -3,8 +3,7 @@ from bs4 import BeautifulSoup
 
 
 def get_title_from_url(slack_url):
-    if 'http' not in slack_url:
-        slack_url = 'http://' + slack_url
+    slack_url = check_for_http_in_url(slack_url)
 
     soup_url = BeautifulSoup(requests.get(slack_url).text)
     try:
@@ -13,3 +12,7 @@ def get_title_from_url(slack_url):
         title = soup_url.find('title').string
 
     return title
+
+
+def check_for_http_in_url(slack_url):
+    return 'http://' + slack_url if 'http' not in slack_url else slack_url

--- a/links/utils.py
+++ b/links/utils.py
@@ -3,7 +3,7 @@ from bs4 import BeautifulSoup
 
 
 def get_title_from_url(slack_url):
-    slack_url = check_for_http_in_url(slack_url)
+    slack_url = ensure_http_prefix(slack_url)
 
     soup_url = BeautifulSoup(requests.get(slack_url).text)
     try:

--- a/links/utils.py
+++ b/links/utils.py
@@ -14,5 +14,5 @@ def get_title_from_url(slack_url):
     return title
 
 
-def check_for_http_in_url(slack_url):
+def ensure_http_prefix(slack_url):
     return 'http://' + slack_url if 'http' not in slack_url else slack_url


### PR DESCRIPTION
Link to task: https://github.com/labcodes/knowledge/issues/27

How to test:
- Use the form or the command /knowledge and to send a link without http.