### PR TITLE
Refs #25 - Error 500 on links without title

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -12,7 +12,7 @@ class CreateSlackNewLinkView(APIView):
 
         try:
             Link.objects.create_from_slack(text, user_id)
-        except ValueError:
+        except (ValueError, ConnectionError):
             return Response({
                 'text': 'Your Link is not valid. Please check your url.'
             }, status=status.HTTP_400_BAD_REQUEST)

--- a/links/templates/links/create-link-form.html
+++ b/links/templates/links/create-link-form.html
@@ -6,6 +6,13 @@
         <div class="row">
           <div class="col-xs-12">
             <h1>Add a new link <button class="btn btn-default logout-button"><a href="{% url 'core:logout' %}">Logout</a></button></h1>
+            {% if messages %}
+              {% for message in messages %}
+              <div class="alert alert-danger text-center">
+               {{message}}
+              </div>
+              {% endfor %}
+            {% endif %}
           </div>
         </div>
       </div>

--- a/links/tests/test_views.py
+++ b/links/tests/test_views.py
@@ -109,6 +109,6 @@ def test_slack_new_invalid_link_in_view(client):
 
 
 @pytest.mark.django_db
-def test_slack_new_invalid_link_in_link_manager(client):
-    with pytest.raises(ValueError):
-        Link.objects.create_from_slack('TreeHouse:https://teamtreehouse.com/home', 'U3V3VMPFC')
+def test_slack_new_invalid_link_in_link_manager(client, mock_slack_notification):
+    with pytest.raises(ConnectionError):
+        Link.objects.create_from_slack('http://raiseconnectionerror.com/', 'U3V3VMPFC')

--- a/links/tests/test_views.py
+++ b/links/tests/test_views.py
@@ -3,6 +3,7 @@ import re
 from django.contrib.auth.models import User
 from model_mommy import mommy
 from links.models import Link
+from requests.exceptions import ConnectionError
 
 
 @pytest.mark.django_db

--- a/links/utils.py
+++ b/links/utils.py
@@ -5,9 +5,19 @@ from bs4 import BeautifulSoup
 def get_title_from_url(slack_url):
     slack_url = ensure_http_prefix(slack_url)
 
-    soup_url = BeautifulSoup(requests.get(slack_url).text)
     try:
-        title = soup_url.find('meta', property='og:title').get('content')
+        soup_url = BeautifulSoup(requests.get(slack_url).text)
+    except:
+        raise ConnectionError
+
+    try:
+        title = soup_url.find('meta', property='og:title')
+
+        if title:
+            title = soup_url.get('content')
+        else:
+            title = soup_url.find('title').string
+
     except AttributeError:
         title = soup_url.find('title').string
 

--- a/links/utils.py
+++ b/links/utils.py
@@ -19,7 +19,9 @@ def get_title_from_url(slack_url):
             title = soup_url.find('title').string
 
     except AttributeError:
-        title = soup_url.find('title').string
+        slashes_index = slack_url.find('//')
+        dot_separation = slack_url.find('.')
+        title = slack_url[slashes_index + 2:dot_separation]
 
     return title
 

--- a/links/utils.py
+++ b/links/utils.py
@@ -1,5 +1,6 @@
 import requests
 from bs4 import BeautifulSoup
+from requests.exceptions import ConnectionError
 
 
 def get_title_from_url(slack_url):
@@ -7,10 +8,7 @@ def get_title_from_url(slack_url):
 
     try:
         soup_url = BeautifulSoup(requests.get(slack_url).text)
-    except:
-        raise ConnectionError
 
-    try:
         meta_tag_with_title = soup_url.find('meta', property='og:title')
 
         if meta_tag_with_title:
@@ -22,6 +20,9 @@ def get_title_from_url(slack_url):
         slashes_index = slack_url.find('//')
         dot_separation = slack_url.find('.')
         title = slack_url[slashes_index + 2:dot_separation]
+
+    except ConnectionError:
+        raise ConnectionError
 
     return title
 

--- a/links/utils.py
+++ b/links/utils.py
@@ -11,10 +11,10 @@ def get_title_from_url(slack_url):
         raise ConnectionError
 
     try:
-        title = soup_url.find('meta', property='og:title')
+        meta_tag_with_title = soup_url.find('meta', property='og:title')
 
-        if title:
-            title = soup_url.get('content')
+        if meta_tag_with_title:
+            title = meta_tag_with_title.get('content')
         else:
             title = soup_url.find('title').string
 

--- a/links/views.py
+++ b/links/views.py
@@ -10,6 +10,8 @@ from .models import Link
 from .forms import LinkForm
 
 from django.shortcuts import redirect
+from requests.exceptions import ConnectionError
+from django.contrib import messages
 
 
 class ListLinksView(LoginRequiredMixin, ListView):
@@ -26,5 +28,9 @@ class CreateLinkView(CreateView):
 
 
     def form_valid(self, form):
-        form.save(author=self.request.user)
+        try:
+            form.save(author=self.request.user)
+        except ConnectionError:
+            messages.error(self.request, "Your Link is not valid. Please check your url.")
+
         return redirect(self.success_url)


### PR DESCRIPTION
Link to task: https://github.com/labcodes/knowledge/issues/25

How to test:
- Submit a link that not exist from slack and from the web app like **http://teste.com** (test.com is going to work, it's a real site)
- It should take the what's between '//' and the domain to use as the title