### PR TITLE
Title is optional now

### DIFF
--- a/links/serializers.py
+++ b/links/serializers.py
@@ -3,7 +3,7 @@ from rest_framework import serializers
 
 
 class LinkSerializer(serializers.Serializer):
-    title = serializers.CharField()
+    title = serializers.CharField(required=False)
     published_at = serializers.SerializerMethodField(source="created")
     url = serializers.URLField()
     author = serializers.CharField(read_only=True)


### PR DESCRIPTION
When you send a link through the browser, title must be optional as well as it is for the links that comes from Slack.